### PR TITLE
fix logout flow

### DIFF
--- a/src/hooks/use-auth.tsx
+++ b/src/hooks/use-auth.tsx
@@ -29,23 +29,29 @@ const useMeQuery = () => {
   return api.me.getMe.useQuery()
 }
 
-const useLogoutMutation = () => {
-  return useMutation({
-    mutationFn: async () => {
-      try {
-        axios.post("/api/cas-logout")
-        window.location.href = "/"
-      } catch (error) {
-        log.error({ error }, "Erro ao fazer logout")
-      }
-    },
-  })
-}
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const useLogoutMutation = () => {
+    return useMutation({
+      mutationFn: async () => {
+        try {
+          await axios.post("/api/cas-logout")
+          //window.location.href = "/"
+        } catch (error) {
+          log.error({ error }, "Erro ao fazer logout")
+  
+        }
+      },
+      onSuccess: async () => {
+          await utils.me.getMe.reset() // or utils.invalidate()
+          // window.location.replace("/login") // or router.replace("/login")
+      },
+    })
+  }
   const router = useRouter()
   const { data: userQuery, isLoading: isLoadingUser } = useMeQuery()
   const logoutMutation = useLogoutMutation()
+  const utils = api.useUtils();
 
   const user = useMemo(() => (userQuery?.id ? userQuery : null), [userQuery])
 
@@ -54,8 +60,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [])
 
   const signOut = useCallback(async () => {
-    await logoutMutation.mutateAsync()
-  }, [logoutMutation])
+    window.location.href = "/api/cas-logout";
+  }, [])
 
   const value = useMemo(
     () => ({


### PR DESCRIPTION
SCRUM-23 - "Remover Cookie UFBA no logout." 

Apenas remover o cookie no logout não deslogava o usuário realmente porque ele permanecia autenticado na UFBA. Então, ajustei o fluxo de logout para encerrar a sessão local (Lucia), e deslogar na UFBA. 

No cliente, troquei o código anterior de logout, que utilizava axios.post + React Query, por navegação de página (mesmo padrão do login): 

const signOut = useCallback(async () => { window.location.href = "/api/cas-logout"; }, []) 

Essa rota de logout (/api/cas-logout), anteriormente, retornava 200 e enviava um cookie em branco para remover a sessão do usuário, mas isso não funcionava porque: 

1. O servidor ainda reconhecia a sessão e emitia um novo cookie. 
2. O usuário permanecia autenticado na Central de Autenticação (CA) da UFBA. 

Minhas mudanças no servidor: 

1. Envio cookie em branco para o cliente (isso já estava sendo feito, apaga a sessão no cliente) 
2. Invalido a sessão local no servidor (o que apaga a sessão no servidor nextjs) 
3. Redireciono o sistema para o logout da CA da UFBA. 

Agora, ao clicar em Sair, o cookie é removido e o usuário é redirecionado para a tela da CA da UFBA, pedindo uma nova autenticação.

Segue vídeo.


https://github.com/user-attachments/assets/8f420ae7-a46e-46b6-b0f1-7475ab782c59

