### PR TITLE
feat: remove CAS (UFBA email) login option

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -13,7 +13,7 @@ import { LoginUserInput, loginUserSchema } from "@/types"
 import { toast } from "sonner"
 
 export default function LoginPage() {
-  const { signInLocal, signInCas, errors, clearErrors } = useAuth()
+  const { signInLocal, errors, clearErrors } = useAuth()
 
   const form = useForm<LoginUserInput>({
     resolver: zodResolver(loginUserSchema),
@@ -37,12 +37,11 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="grid gap-8 md:grid-cols-[1.2fr_1fr]">
-      <div className="space-y-6">
+    <div className="flex justify-center">
+      <div className="space-y-6 w-full max-w-md">
         <h1 className="text-3xl font-bold text-slate-900">Bem-vindo de volta</h1>
         <p className="text-slate-600 text-sm leading-relaxed">
-          Faça login com seu e-mail institucional para acessar o Sistema de Monitoria IC. Caso possua acesso via UFBA,
-          você também pode utilizar o login UFBA.
+          Faça login com seu e-mail institucional para acessar o Sistema de Monitoria IC.
         </p>
 
         <div className="rounded-lg border border-slate-200 p-6 bg-white shadow-sm">
@@ -95,26 +94,6 @@ export default function LoginPage() {
           </div>
         </div>
       </div>
-
-      <aside className="h-full w-full rounded-xl bg-gradient-to-br from-blue-500 via-blue-600 to-blue-700 text-white p-8 shadow-xl">
-        <div className="space-y-6">
-          <h2 className="text-2xl font-semibold">Prefere o acesso institucional via e-mail UFBA?</h2>
-          <p className="text-blue-100 text-sm leading-relaxed">
-            Utilize o login via e-mail UFBA para aproveitar autenticação automática com sua conta UFBA. Ideal para
-            professores e estudantes que já possuem credenciais institucionais ativas.
-          </p>
-
-          <Button variant="secondary" className="w-full" onClick={signInCas}>
-            Entrar com e-mail UFBA
-          </Button>
-
-          <div className="text-xs text-blue-50 space-y-2">
-            <p>• Professores e alunos podem optar por qualquer método de autenticação.</p>
-            <p>• Após criar sua conta por e-mail, confirme o endereço informado para ativar o acesso.</p>
-            <p>• Caso tenha dificuldades com a autenticação via e-mail UFBA, utilize o login local como alternativa.</p>
-          </div>
-        </div>
-      </aside>
     </div>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,9 @@
 "use client"
 import { Footer } from "@/components/layout/Footer"
 import { Button } from "@/components/ui/button"
-import { useAuth } from "@/hooks/use-auth"
 import Link from "next/link"
 
 export default function LandingPageComponent() {
-  const { signInCas } = useAuth()
-
   return (
     <div className="flex flex-col min-h-screen bg-gradient-to-b from-gray-50 to-white">
       <header className="sticky top-0 z-10 p-4 border-b bg-white/80 backdrop-blur-sm">
@@ -16,14 +13,9 @@ export default function LandingPageComponent() {
             <span className="text-xl font-bold text-[hsl(195,71%,40%)]">Sistema de Monitoria IC</span>
           </div>
           <div className="w-full sm:w-auto flex justify-center sm:justify-end mt-4 sm:mt-0">
-            <div className="flex gap-2 w-full sm:w-auto">
-              <Button className="w-full sm:w-auto" onClick={signInCas}>
-                Entrar com e-mail UFBA
-              </Button>
-              <Button asChild variant="outline" className="w-full sm:w-auto">
-                <Link href="/auth/login">Entrar com e-mail</Link>
-              </Button>
-            </div>
+            <Button asChild className="w-full sm:w-auto">
+              <Link href="/auth/login">Entrar</Link>
+            </Button>
           </div>
         </div>
       </header>
@@ -37,11 +29,11 @@ export default function LandingPageComponent() {
               UFBA.
             </p>
             <div className="flex flex-col sm:flex-row gap-3">
-              <Button size="lg" onClick={signInCas}>
-                Entrar com e-mail UFBA
+              <Button asChild size="lg">
+                <Link href="/auth/login">Entrar</Link>
               </Button>
               <Button asChild size="lg" variant="outline">
-                <Link href="/auth/register">Criar conta com e-mail</Link>
+                <Link href="/auth/register">Criar conta</Link>
               </Button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
Remove UFBA institutional email (CAS) authentication from UI to simplify login flow.

## Changes
- Remove CAS login button and aside section from login page
- Remove CAS login buttons from landing page header and hero
- Simplify login page layout to single column centered design
- Update button labels to be more concise ("Entrar" instead of "Entrar com e-mail")

## Files Modified
- [src/app/auth/login/page.tsx](src/app/auth/login/page.tsx): Removed signInCas hook and entire CAS login aside
- [src/app/page.tsx](src/app/page.tsx): Removed signInCas hook and all CAS login buttons

## Testing
- ✅ Build successful
- ✅ All tests passing (57/57)
- ✅ TypeScript checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)